### PR TITLE
Add sensitive flag to vars and outputs that are secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *_override.tf.json
 *.tfstate
 *.tfstate.*
+*.tfvars
 **/.terraform/*
 crash.log
 override.tf

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -18,6 +18,7 @@ variable "instance_type" {
 variable "password" {
   description = "The db password used to connect to the Postgers db"
   type        = string
+  sensitive   = true
 }
 
 variable "user" {

--- a/modules/serviceaccount/outputs.tf
+++ b/modules/serviceaccount/outputs.tf
@@ -4,5 +4,6 @@ output "email" {
 }
 
 output "private_key" {
-  value = base64decode(google_service_account_key.key.private_key)
+  value     = base64decode(google_service_account_key.key.private_key)
+  sensitive = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,4 +3,5 @@
 variable "db_password" {
   description = "The Postgres password"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
By setting `sensitive = true` on a variable or output, Terraform will redact it from the plan/apply output. This prevents secrets from being logged. This is a new feature in Terraform v0.14.